### PR TITLE
fix bugs in product registration

### DIFF
--- a/app/Http/Controllers/Owner/ProductController.php
+++ b/app/Http/Controllers/Owner/ProductController.php
@@ -91,6 +91,7 @@ class ProductController extends Controller
 
                 Stock::create([
                     'product_id' => $product->id,
+                    'user_id' => NULL,
                     'type' => 1,
                     'quantity' => $request->quantity,
                 ]);

--- a/database/factories/StockFactory.php
+++ b/database/factories/StockFactory.php
@@ -20,7 +20,7 @@ class StockFactory extends Factory
         return [
             'product_id' => Product::factory(),
             'user_id' => NULL,
-            'type' => $this->faker->numberBetween(1, 2),
+            'type' => 1,
             'quantity' => $this->faker->numberBetween(10, 999),
         ];
     }

--- a/database/factories/StockFactory.php
+++ b/database/factories/StockFactory.php
@@ -19,7 +19,7 @@ class StockFactory extends Factory
     {
         return [
             'product_id' => Product::factory(),
-            'user_id' => $this->faker->numberBetween(1, 3),
+            'user_id' => NULL,
             'type' => $this->faker->numberBetween(1, 2),
             'quantity' => $this->faker->numberBetween(10, 999),
         ];

--- a/database/migrations/2023_05_14_095122_create_stocks_table.php
+++ b/database/migrations/2023_05_14_095122_create_stocks_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             ->onUpdate('cascade')
             ->onDelete('cascade');
             $table->foreignId('user_id')
+            ->nullable()
             ->constrained()
             ->onUpdate('cascade')
             ->onDelete('cascade');

--- a/resources/views/profile/partials/purchase-history.blade.php
+++ b/resources/views/profile/partials/purchase-history.blade.php
@@ -5,20 +5,24 @@
         </h2>
     </header>
 
-    @foreach ($stocks as $stock)
-        <div class="md:flex my-2">
-            <div class="md:w-3/12">
-                <x-thumbnail filename="{{ $stock->filename ?? '' }}" type="products" />
-            </div>
-            <div class="md:w-8/12 md:ml-4">
-                <div class="mb-2">
-                    商品名：{{ $stock->name }}<br>
-                    数量：{{ $stock->quantity }}個<br>
-                    単価：{{ number_format($stock->price) }}<span class="text-sm text-gray-700">円(税込)</span><br>
-                    小計：{{ number_format($stock->quantity * $stock->price) }}<span class="text-sm text-gray-700">円(税込)</span><br>
-                    購入日時：{{ \Carbon\Carbon::parse($stock->created_at)->format('Y年n月j日 G時i分') }}<br><br>
+    @if ($stocks->isEmpty())
+        <p class="text-center">商品を購入した履歴はありません。</p>
+    @else
+        @foreach ($stocks as $stock)
+            <div class="md:flex my-2">
+                <div class="md:w-3/12">
+                    <x-thumbnail filename="{{ $stock->filename ?? '' }}" type="products" />
+                </div>
+                <div class="md:w-8/12 md:ml-4">
+                    <div class="mb-2">
+                        商品名：{{ $stock->name }}<br>
+                        数量：{{ $stock->quantity }}個<br>
+                        単価：{{ number_format($stock->price) }}<span class="text-sm text-gray-700">円(税込)</span><br>
+                        小計：{{ number_format($stock->quantity * $stock->price) }}<span class="text-sm text-gray-700">円(税込)</span><br>
+                        購入日時：{{ \Carbon\Carbon::parse($stock->created_at)->format('Y年n月j日 G時i分') }}<br><br>
+                    </div>
                 </div>
             </div>
-        </div>
-    @endforeach
+        @endforeach
+    @endif
 </section>


### PR DESCRIPTION
- 商品登録における不具合を修正。
  - `t_stocks`テーブルの`user_id`カラムに対して、`NULL`を許容する設定を行う。
  - 商品新規登録処理を行う場合、`user_id`カラムに`NULL`を挿入する。
  - ユーザーがカートに入れた商品を購入しようとする（Stripe画面に遷移する）際や、実際に決済処理を行ったときに、`user_id`に値が格納される。
- 一度も商品を購入したことがないユーザーに対して、プロフィール画面の購入履歴にて、「商品を購入した履歴はありません。」と表示。
- 初期データ（factory）において、`t_stocks`テーブルの`type`カラムには、1のみ挿入。
```
※ t_stocksテーブルのtypeカラムの値について
1：通常時（出品されているだけ）
2：決済（Stripe）画面に遷移（在庫を一時的に減らす）
3：商品購入済み（決済処理完了）
```